### PR TITLE
Make this a brainfuck interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ overhead, like so:
 The functions each do their thing, and bump the IP to move to the
 next instruction.
 
-* NOTE
-  * To handle loops we use a parallel input which is sub-optimal, but we live with it for the purposes of simplicity.
+* **NOTE**
+  * We kind cheat when it comes to STDOUT writing - we buffer output until we see a newline.
+  * This boosts the mandelbrot benchmark by about five seconds.
+  * I think it's a legitimate optimization, but it might be that you disagree.
 
 
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,15 @@ overhead, like so:
 The functions each do their thing, and bump the IP to move to the
 next instruction.
 
-* **NOTE**
-  * We kind cheat when it comes to STDOUT writing - we buffer output until we see a newline.
-  * This boosts the mandelbrot benchmark by about five seconds.
-  * I think it's a legitimate optimization, but it might be that you disagree.
+
+
+## STDOUT Buffering
+
+Brainfuck has only a pair of primitives for reading and writing to the console, and these work on single bytes at a time.  By default we buffer writes to STDOUT until we see a newline, which boosts the mandelbrot benchmark a decent amount.
+
+I think it's a legitimate optimization, but if you wish to disable it set the environmental variable `BUFFER_STDOUT` to the literal string `false`.
+
+You'll see that this has no runtime impact, the change here is in the compilation phase where we use a different closure depending on the value of the variable.
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,24 @@
 # simple vm
 
-This repository contains a trivial virtual machine, to demonstrate the usage of an interpreter which is faster than using a naive bytecode-based approach.
+This repository contains a trivial interpreter for brainfuck, which
+is designed to demonstrate the usage of an interpreter which is faster than using a naive bytecode-based approach, and which instead uses
+a series of closures to implement each "op".
 
-Instead of compiling a program into a series of bytecode values, which are then interpreted by a giant switch-statement we can instead just compile a series of function-pointers - the function being the thing that does whatever is required of course.
-
-Our interpreter is then very simple:
+Instead of compiling a program into a series of bytecode values, which are then interpreted by a giant switch-statement we compile each small
+operation into a closure which can be implemented without the switch
+overhead, like so:
 
     ...
 	for ip < len(code) {
-		ip += code[ip](vm)
+        code[ip](vm)
 	}
     ..
 
-The functions each return a value which controls where to execute next.  Most functions would return 1 to move to the next "instruction" but we could implement control-flow by bumping forwards/backwards as appropriate.
+The functions each do their thing, and bump the IP to move to the
+next instruction.
+
+* NOTE
+  * To handle loops we use a parallel input which is sub-optimal, but we live with it for the purposes of simplicity.
 
 
 

--- a/main.go
+++ b/main.go
@@ -1,63 +1,263 @@
-// package main contains a simple "interpreter"
+// package main contains a simple brainfuck interpreter which compiles
+// a program into a series of closures which can then be iterated
+// over in turn.
 //
-// This interpreter is the skeleton of a virtual machine which is built upon
-// the design of using closures to populate function-pointers which are then
-// executed in turn.
+// The intent behind this implementation is to show how a "real"
+// interpreter might work, built without the traditional approach
+// of compiling to, and walking, a series of bytecode values.
+//
+// Bytecode interpreters are faster than AST-walking interpreters
+// however they need to have a lot of internal duplication:
+//
+// * Some part of the code emits bytecode for each operation.
+//
+// * Some part of the code "does stuff" for each bytecode opcode.
+//
+// Keeping those two things in sync is annoying overhead, and also
+// the traditional "switch-based" interpretation of bytecode opcodes
+// is slow.
+//
+// The idea here is that we walk over a series of function-pointers
+// and that is going to be fast.  We can do that because we generated
+// a series of closures containing each "opcode thing".
 package main
 
 import (
 	"errors"
 	"fmt"
+	"os"
 )
 
-// VM contains the virtual machine, it mostly exists to host a stack and a
-// program which has been "compiled" into a series of function-pointers.
-//
-// The VM will execute a program by calling each function-pointer in turn,
-// and those functions will be closures that mutate the state of the VM as
-// side-effects.
-type VM struct {
-	// stack contains arguments which are passed to our minimal operations.
-	stack []float64
+var (
+	// ErrExit is a faux error we append to the end of all our
+	// input programs, and can thus be used to detect the end
+	// of a program.
+	ErrExit = errors.New("EXIT")
+)
 
-	// program contains the program we're going to execute.
+// VM contains the virtual machine, and it mostly exists to hold
+// the state of our brainfuck program.
+//
+// The state is both our compiled closures, and some notes for
+// interpretation (i.e. helpers for the loop-counters & etc).
+type VM struct {
+
+	// brainfuck stuff
+
+	// ip is the instruction pointer into the brainfuck
+	// program which is to be executed.
+	ip int
+
+	// ptr is the brainfuck programs index offset.
+	ptr int
+
+	// memory is the memory-space the brainfuck program uses
+	memory [30000]int
+
+	// loops is used to lookup look bounds
+	loops map[int]int
+
+	// driver
+
+	// program contains the set of closures that we can
+	// execute one by one, to run the actual user program
 	program []vmFunc
 
 	// err records any error received when running the program.
 	err error
 }
 
-// New is the VM constructor
-func New(prog []vmFunc) *VM {
-	return &VM{program: prog}
+// New is the VM constructor which takes our program as input
+// and compiles it into a series of closures.  Some basic problems
+// are detected and returned here.
+func New(bf string) (*VM, error) {
+
+	// Create empty VM
+	v := VM{}
+
+	v.loops = make(map[int]int)
+	loopStack := []int{}
+
+	// Ensure we got a program
+	if len(bf) < 1 {
+		return nil, errors.New("empty program is invalid")
+	}
+
+	// Index and bounds
+	i := 0
+	max := len(bf)
+
+	// Walk each character
+	for i < max {
+
+		// Handle each known character
+		c := bf[i]
+
+		switch c {
+		case '+':
+
+			// Record our starting position
+			begin := i
+
+			// Loop forward to see how many times the character
+			// is repeated.
+			for i < max {
+
+				// If it isn't the same character
+				// we're done
+				if bf[i] != c {
+					break
+				}
+
+				// Otherwise keep advancing forward
+				i++
+			}
+
+			// Return the token and the times it was
+			// seen in adjacent positions
+			count := i - begin
+
+			i -= 1
+			v.program = append(v.program, makeIncCell(count))
+		case '-':
+			// Record our starting position
+			begin := i
+
+			// Loop forward to see how many times the character
+			// is repeated.
+			for i < max {
+
+				// If it isn't the same character
+				// we're done
+				if bf[i] != c {
+					break
+				}
+
+				// Otherwise keep advancing forward
+				i++
+			}
+
+			// Return the token and the times it was
+			// seen in adjacent positions
+			count := i - begin
+
+			i -= 1
+			v.program = append(v.program, makeDecCell(count))
+		case '<':
+			// Record our starting position
+			begin := i
+
+			// Loop forward to see how many times the character
+			// is repeated.
+			for i < max {
+
+				// If it isn't the same character
+				// we're done
+				if bf[i] != c {
+					break
+				}
+
+				// Otherwise keep advancing forward
+				i++
+			}
+
+			// Return the token and the times it was
+			// seen in adjacent positions
+			count := i - begin
+
+			i -= 1
+			v.program = append(v.program, makeDecPtr(count))
+		case '>':
+			// Record our starting position
+			begin := i
+
+			// Loop forward to see how many times the character
+			// is repeated.
+			for i < max {
+
+				// If it isn't the same character
+				// we're done
+				if bf[i] != c {
+					break
+				}
+
+				// Otherwise keep advancing forward
+				i++
+			}
+
+			// Return the token and the times it was
+			// seen in adjacent positions
+			count := i - begin
+
+			i -= 1
+			v.program = append(v.program, makeIncPtr(count))
+		case ',':
+			v.program = append(v.program, makeRead())
+		case '.':
+			v.program = append(v.program, makeWrite())
+		case '[':
+			// loop open
+			loopStack = append(loopStack, len(v.program))
+
+			v.program = append(v.program, makeLoopOpen())
+
+		case ']':
+			// Pop position of last JumpIfZero ("[") instruction off stack
+			openInstruction := loopStack[len(loopStack)-1]
+			loopStack = loopStack[:len(loopStack)-1]
+
+			// loop points to the end
+			v.loops[openInstruction] = len(v.program)
+
+			// end points to start
+			v.loops[len(v.program)] = openInstruction
+
+			// Now add the instruction
+			v.program = append(v.program, makeLoopClose())
+		default:
+			// Invalid character.
+			// ignored.
+		}
+		i++
+	}
+
+	// Add a fake "exit" trap to the end of our program
+	v.program = append(v.program, makeExit())
+
+	return &v, nil
 }
 
 // RunProgram executes the program which was given in the constructor.
 func (vm *VM) RunProgram() error {
 
-	// Reset the state of the stack each run.
-	vm.stack = []float64{}
+	// Reset the state of the program each run.
+	vm.ptr = 0
+	vm.ip = 0
 
 	// Execute the program.
 	code := vm.program
-	ip := 0
 
 	// For each operation.  Run it
-	for ip < len(code) {
+	for vm.ip < len(code) {
 
-		// Here the return value controls which operation
-		// we execute next by changing the offset within
-		// the code-array.
+		// Call the closure.
 		//
-		// We could allow loops by having the opcodes return
-		// different values.  In this example we only move
-		// forwards.
-		ip += code[ip](vm)
+		// Here we assume that each opcode ends with
+		// "vm.ip++", which lets us run forward.
+		code[vm.ip](vm)
 
+		// Did we get an error?
 		if vm.err != nil {
+
+			// If it is the fake exit-program error
+			// then we ignore it.
+			if vm.err == ErrExit {
+				return nil
+			}
+
+			// otherwise return the error to the caller
 			return vm.err
 		}
-
 	}
 
 	return nil
@@ -68,97 +268,97 @@ func (vm *VM) RunProgram() error {
 //
 
 // vmFunc is the type-signature of a mutating primitive we would implement.
-type vmFunc func(vm *VM) int
+type vmFunc func(vm *VM)
 
-// newInt creates, and returns, a closure which adds the float value to the program stack.
-func newInt(n float64) vmFunc {
-	return func(v *VM) int {
-		v.stack = append(v.stack, n)
-		return 1
+// makeExit: brainfuck implementation
+func makeExit() vmFunc {
+	return func(v *VM) {
+		v.err = ErrExit
 	}
 }
 
-// addOp creates, and returns, a closure which adds two numbers via the stack.
-//
-// We're stack-based so we pop our arguments, run the operation, and push the result.
-func addOp() vmFunc {
-
-	return func(v *VM) int {
-		x := 0.0
-		y := 0.0
-
-		if len(v.stack) < 2 {
-			v.err = errors.New("stack underflow")
-			return 0
-		}
-
-		x, v.stack = v.stack[len(v.stack)-1], v.stack[:len(v.stack)-1]
-		y, v.stack = v.stack[len(v.stack)-1], v.stack[:len(v.stack)-1]
-
-		v.stack = append(v.stack, x+y)
-		return 1
+// makeIncCell: brainfuck implementation
+func makeIncCell(n int) vmFunc {
+	return func(v *VM) {
+		v.memory[v.ptr] += n
+		v.ip += 1
 	}
 }
 
-// mulOp creates, and returns, a closure which multiplies two numbers via the stack.
-//
-// We're stack-based so we pop our arguments, run the operation, and push the result.
-func mulOp() vmFunc {
-
-	return func(v *VM) int {
-		x := 0.0
-		y := 0.0
-
-		if len(v.stack) < 2 {
-			v.err = errors.New("stack underflow")
-			return 0
-		}
-
-		x, v.stack = v.stack[len(v.stack)-1], v.stack[:len(v.stack)-1]
-		y, v.stack = v.stack[len(v.stack)-1], v.stack[:len(v.stack)-1]
-
-		v.stack = append(v.stack, x*y)
-		return 1
+// makeDecCell: brainfuck implementation
+func makeDecCell(n int) vmFunc {
+	return func(v *VM) {
+		v.memory[v.ptr] -= n
+		v.ip += 1
 	}
 }
 
-// divOp creates, and returns, a closure which divides two numbers via the stack.
-//
-// We're stack-based so we pop our arguments, run the operation, and push the result.
-func divOp() vmFunc {
-
-	return func(v *VM) int {
-		x := 0.0
-		y := 0.0
-
-		if len(v.stack) < 2 {
-			v.err = errors.New("stack underflow")
-			return 0
-		}
-
-		x, v.stack = v.stack[len(v.stack)-1], v.stack[:len(v.stack)-1]
-		y, v.stack = v.stack[len(v.stack)-1], v.stack[:len(v.stack)-1]
-
-		if y == 0 {
-			v.err = errors.New("division by zero")
-			return 0
-		}
-
-		v.stack = append(v.stack, x/y)
-		return 1
+// makeIncPtr: brainfuck implementation
+func makeIncPtr(n int) vmFunc {
+	return func(v *VM) {
+		v.ptr += n
+		v.ip += 1
 	}
 }
 
-// printOp shows the value at the top of the stack.
-func printOp() vmFunc {
-	return func(v *VM) int {
-		if len(v.stack) < 1 {
-			v.err = errors.New("stack underflow")
-			return 0
+// makeDecPtr: brainfuck implementation
+func makeDecPtr(n int) vmFunc {
+	return func(v *VM) {
+		v.ptr -= n
+		v.ip += 1
+	}
+}
+
+// makeRead: brainfuck implementation
+func makeRead() vmFunc {
+	return func(v *VM) {
+		buf := make([]byte, 1)
+		l, err := os.Stdin.Read(buf)
+		if err != nil {
+			v.err = err
+			return
+		}
+		if l != 1 {
+			v.err = fmt.Errorf("read %d bytes of input, not 1", l)
+			return
+		}
+		v.memory[v.ptr] = int(buf[0])
+		v.ip += 1
+	}
+}
+
+// makeWrite: brainfuck implementation
+func makeWrite() vmFunc {
+	return func(v *VM) {
+		fmt.Printf("%c", rune(v.memory[v.ptr]))
+		v.ip += 1
+	}
+}
+
+// makeLoopOpen: brainfuck implementation
+func makeLoopOpen() vmFunc {
+	return func(v *VM) {
+		// early termination
+		if v.memory[v.ptr] != 0x00 {
+			v.ip += 1
+			return
 		}
 
-		fmt.Printf("%f\n", v.stack[len(v.stack)-1])
-		return 1
+		v.ip = v.loops[v.ip]
+	}
+}
+
+// makeLoopClose: brainfuck implementation
+func makeLoopClose() vmFunc {
+	return func(v *VM) {
+
+		// early termination
+		if v.memory[v.ptr] == 0x00 {
+			v.ip++
+			return
+		}
+
+		v.ip = v.loops[v.ip]
 	}
 }
 
@@ -169,22 +369,28 @@ func printOp() vmFunc {
 // main is our entry-point and creates/runs a program.
 func main() {
 
-	// Create a basic program.
-	prog := []vmFunc{}
-	prog = append(prog, newInt(3))
-	prog = append(prog, newInt(7))
-	prog = append(prog, addOp()) // 3 + 7
-	prog = append(prog, printOp())
+	// No arguments?  Abort
+	if len(os.Args) != 2 {
+		fmt.Printf("Usage: simple-vm path/to/file.bf\n")
+		return
+	}
 
-	prog = append(prog, newInt(4.5)) // [10] * 4.5
-	prog = append(prog, mulOp())
-	prog = append(prog, printOp())
+	// Read the file
+	dat, err := os.ReadFile(os.Args[1])
+	if err != nil {
+		fmt.Printf("Error reading %s:%s\n", os.Args[1], err)
+		return
+	}
 
 	// create an interpreter to run that program.
-	v := New(prog)
+	v, err := New(string(dat))
+	if err != nil {
+		fmt.Printf("error compiling program: %s\n", err.Error())
+		return
+	}
 
 	// now launch it
-	err := v.RunProgram()
+	err = v.RunProgram()
 	if err != nil {
 		fmt.Printf("error running program: %s\n", err)
 	}

--- a/main.go
+++ b/main.go
@@ -133,7 +133,7 @@ func New(bf string) (*VM, error) {
 			// seen in adjacent positions
 			count := i - begin
 
-			i -= 1
+			i--
 			v.program = append(v.program, makeIncCell(count))
 		case '-':
 			// Record our starting position
@@ -157,7 +157,7 @@ func New(bf string) (*VM, error) {
 			// seen in adjacent positions
 			count := i - begin
 
-			i -= 1
+			i--
 			v.program = append(v.program, makeDecCell(count))
 		case '<':
 			// Record our starting position
@@ -181,7 +181,7 @@ func New(bf string) (*VM, error) {
 			// seen in adjacent positions
 			count := i - begin
 
-			i -= 1
+			i--
 			v.program = append(v.program, makeDecPtr(count))
 		case '>':
 			// Record our starting position
@@ -205,7 +205,7 @@ func New(bf string) (*VM, error) {
 			// seen in adjacent positions
 			count := i - begin
 
-			i -= 1
+			i--
 			v.program = append(v.program, makeIncPtr(count))
 		case ',':
 			v.program = append(v.program, makeRead())
@@ -301,7 +301,7 @@ func makeExit() vmFunc {
 func makeIncCell(n int) vmFunc {
 	return func(v *VM) {
 		v.memory[v.ptr] += n
-		v.ip += 1
+		v.ip++
 	}
 }
 
@@ -309,7 +309,7 @@ func makeIncCell(n int) vmFunc {
 func makeDecCell(n int) vmFunc {
 	return func(v *VM) {
 		v.memory[v.ptr] -= n
-		v.ip += 1
+		v.ip++
 	}
 }
 
@@ -317,7 +317,7 @@ func makeDecCell(n int) vmFunc {
 func makeIncPtr(n int) vmFunc {
 	return func(v *VM) {
 		v.ptr += n
-		v.ip += 1
+		v.ip++
 	}
 }
 
@@ -325,7 +325,7 @@ func makeIncPtr(n int) vmFunc {
 func makeDecPtr(n int) vmFunc {
 	return func(v *VM) {
 		v.ptr -= n
-		v.ip += 1
+		v.ip++
 	}
 }
 
@@ -343,7 +343,7 @@ func makeRead() vmFunc {
 			return
 		}
 		v.memory[v.ptr] = int(buf[0])
-		v.ip += 1
+		v.ip++
 	}
 }
 
@@ -360,9 +360,9 @@ func makeWrite() vmFunc {
 			v.stdout = ""
 		} else {
 			// otherwise save away
-			v.stdout += string(v.memory[v.ptr])
+			v.stdout += string(rune(v.memory[v.ptr]))
 		}
-		v.ip += 1
+		v.ip++
 	}
 }
 
@@ -371,7 +371,7 @@ func makeLoopOpen() vmFunc {
 	return func(v *VM) {
 		// early termination
 		if v.memory[v.ptr] != 0x00 {
-			v.ip += 1
+			v.ip++
 			return
 		}
 


### PR DESCRIPTION
This pull-request changes from using a series of closures to run a simple hand-made program to instead being a general purpose brainfuck interpreter.

This is a naive approach and some of the code is not yet perfect which is why this is WIP, that said it works.

The "standard benchmark" is the mandelbrot display, in this implementation on my host I see 35 seconds to draw.  Compare that to the naive VM I have which is about 47 seconds.

So we win, but it's still slow.

This is part of #1, but before merging:

* Remove the duplication on collapsing identical inc/dec/ops
* Test on more code.
* Linter updates.
* Better documentation.

After merging rename this repository.  "closure-based-brainfuck-vm", or similar.